### PR TITLE
Ignore case for operators when searching short-form IDs

### DIFF
--- a/v0/idsearcher/idsearcher.go
+++ b/v0/idsearcher/idsearcher.go
@@ -204,11 +204,6 @@ func getIndividualLicenses(lic string) []string {
 	lic = strings.Replace(lic, "(", " ", -1)
 	lic = strings.Replace(lic, ")", " ", -1)
 
-	// also replace combination words with spaces
-	lic = strings.Replace(lic, " AND ", " ", -1)
-	lic = strings.Replace(lic, " OR ", " ", -1)
-	lic = strings.Replace(lic, " WITH ", " ", -1)
-
 	// now, split by spaces, trim, and add to slice
 	licElements := strings.Split(lic, " ")
 	lics := []string{}

--- a/v0/idsearcher/idsearcher.go
+++ b/v0/idsearcher/idsearcher.go
@@ -214,9 +214,13 @@ func getIndividualLicenses(lic string) []string {
 	lics := []string{}
 	for _, elt := range licElements {
 		elt := strings.TrimSpace(elt)
-		if elt != "" {
-			lics = append(lics, elt)
+		// don't add if empty or if case-insensitive operator
+		if elt == "" || strings.EqualFold(elt, "AND") ||
+			strings.EqualFold(elt, "OR") || strings.EqualFold(elt, "WITH") {
+			continue
 		}
+
+		lics = append(lics, elt)
 	}
 
 	// sort before returning

--- a/v0/idsearcher/idsearcher_test.go
+++ b/v0/idsearcher/idsearcher_test.go
@@ -515,3 +515,57 @@ func TestCanGetIndividualLicenses(t *testing.T) {
 		t.Errorf("expected %v, got %v", "MIT", lics[3])
 	}
 }
+
+func TestCanGetIndividualLicensesIgnoringOperatorCase(t *testing.T) {
+	// two-license combo with lowercase 'and'
+	lic := "ISC and BSD-3-Clause"
+	lics := getIndividualLicenses(lic)
+	if lics == nil {
+		t.Fatalf("expected non-nil lics, got nil")
+	}
+	// should be sorted alphabetically; 'and' should not appear
+	if len(lics) != 2 {
+		t.Fatalf("expected lics to have len 2, got %d", len(lics))
+	}
+	if lics[0] != "BSD-3-Clause" {
+		t.Errorf("expected %v, got %v", "BSD-3-Clause", lics[0])
+	}
+	if lics[1] != "ISC" {
+		t.Errorf("expected %v, got %v", "ISC", lics[1])
+	}
+
+	// two-license combo with lowercase 'or'
+	lic = "ISC or BSD-3-Clause"
+	lics = getIndividualLicenses(lic)
+	if lics == nil {
+		t.Fatalf("expected non-nil lics, got nil")
+	}
+	// should be sorted alphabetically; 'or' should not appear
+	if len(lics) != 2 {
+		t.Fatalf("expected lics to have len 2, got %d", len(lics))
+	}
+	if lics[0] != "BSD-3-Clause" {
+		t.Errorf("expected %v, got %v", "BSD-3-Clause", lics[0])
+	}
+	if lics[1] != "ISC" {
+		t.Errorf("expected %v, got %v", "ISC", lics[1])
+	}
+
+	// two-license combo with lowercase 'with'
+	lic = "GPL-2.0-only with Classpath-exception-2.0"
+	lics = getIndividualLicenses(lic)
+	if lics == nil {
+		t.Fatalf("expected non-nil lics, got nil")
+	}
+	// should be sorted alphabetically; 'with' should not appear
+	if len(lics) != 2 {
+		t.Fatalf("expected lics to have len 2, got %d", len(lics))
+	}
+	if lics[0] != "Classpath-exception-2.0" {
+		t.Errorf("expected %v, got %v", "Classpath-exception-2.0", lics[0])
+	}
+	if lics[1] != "GPL-2.0-only" {
+		t.Errorf("expected %v, got %v", "GPL-2.0-only", lics[1])
+	}
+
+}


### PR DESCRIPTION
Fixes #21 

Signed-off-by: Steve Winslow <swinslow@gmail.com>