### PR TITLE
Deprecate repo with transition to spdx/tools-golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# DEPRECATED
+
+swinslow/spdx-go is now deprecated, as it has been moved to the SPDX Tools project at
+[spdx/tools-golang](https://github.com/spdx/tools-golang).
+
+Please update import links to use the new location instead, as this repo will not be maintained further.
+
+=====
+
 [![Build Status](https://travis-ci.org/swinslow/spdx-go.svg?branch=master)](https://travis-ci.org/swinslow/spdx-go)
 [![Coverage Status](https://coveralls.io/repos/github/swinslow/spdx-go/badge.svg)](https://coveralls.io/github/swinslow/spdx-go)
 


### PR DESCRIPTION
The tools have been moved into https://github.com/spdx/tools-golang, so I am deprecating swinslow/spdx-go. This PR updates the README to reflect this status.

Signed-off-by: Steve Winslow <swinslow@gmail.com>